### PR TITLE
Implement minimal PHP trading skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# codex-test
+# Mini Exchange
+
+This repository contains a minimal example of a cryptocurrency trading platform built with PHP and MySQL.
+
+## Features
+- User registration and login
+- Simple dashboard
+- P2P offer listing
+- Basic market order book display
+
+## Setup
+1. Create a MySQL database named `exchange_db` and import `sql/schema.sql`.
+2. Update database credentials in `config/db.php`.
+3. Deploy the contents of the `public/` directory to a PHP-enabled web server.
+
+This code is provided as a learning example and does not include full security or compliance measures required for production use.

--- a/config/db.php
+++ b/config/db.php
@@ -1,0 +1,19 @@
+<?php
+$host = 'localhost';
+$db   = 'exchange_db';
+$user = 'username';
+$pass = 'password';
+$charset = 'utf8mb4';
+
+$options = [
+    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+    PDO::ATTR_EMULATE_PREPARES   => false,
+];
+
+try {
+    $pdo = new PDO("mysql:host=$host;dbname=$db;charset=$charset", $user, $pass, $options);
+} catch (PDOException $e) {
+    throw new PDOException($e->getMessage(), (int)$e->getCode());
+}
+?>

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -1,0 +1,24 @@
+<?php
+session_start();
+require_once '../config/db.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Dashboard</title>
+</head>
+<body>
+    <h1>Dashboard</h1>
+    <p>Welcome, user #<?php echo $_SESSION['user_id']; ?></p>
+    <ul>
+        <li><a href="p2p_offers.php">P2P Offers</a></li>
+        <li><a href="market.php">Market Trading</a></li>
+        <li><a href="logout.php">Logout</a></li>
+    </ul>
+</body>
+</html>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,17 @@
+<?php
+session_start();
+if (isset($_SESSION['user_id'])) {
+    header('Location: dashboard.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mini Exchange</title>
+</head>
+<body>
+    <h1>Welcome to Mini Exchange</h1>
+    <p><a href="register.php">Register</a> | <a href="login.php">Login</a></p>
+</body>
+</html>

--- a/public/login.php
+++ b/public/login.php
@@ -1,0 +1,34 @@
+<?php
+session_start();
+require_once '../config/db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+    $stmt = $pdo->prepare('SELECT id, password FROM users WHERE email = :email');
+    $stmt->execute([':email' => $email]);
+    $user = $stmt->fetch();
+    if ($user && password_verify($password, $user['password'])) {
+        $_SESSION['user_id'] = $user['id'];
+        header('Location: dashboard.php');
+        exit;
+    }
+    $error = 'Invalid credentials';
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login</title>
+</head>
+<body>
+    <h1>Login</h1>
+    <?php if (!empty($error)) echo '<p style="color:red">'.$error.'</p>'; ?>
+    <form method="post">
+        <label>Email: <input type="email" name="email" required></label><br>
+        <label>Password: <input type="password" name="password" required></label><br>
+        <button type="submit">Login</button>
+    </form>
+    <p><a href="index.php">Home</a></p>
+</body>
+</html>

--- a/public/logout.php
+++ b/public/logout.php
@@ -1,0 +1,5 @@
+<?php
+session_start();
+session_destroy();
+header('Location: index.php');
+exit;

--- a/public/market.php
+++ b/public/market.php
@@ -1,0 +1,34 @@
+<?php
+session_start();
+require_once '../config/db.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+$orders = $pdo->query('SELECT * FROM orders ORDER BY id DESC')->fetchAll();
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Market Trading</title>
+</head>
+<body>
+    <h1>Market Trading</h1>
+    <p>This is a simplified order book.</p>
+    <table border="1">
+        <tr><th>ID</th><th>User</th><th>Side</th><th>Amount</th><th>Price</th></tr>
+        <?php foreach ($orders as $order): ?>
+            <tr>
+                <td><?php echo $order['id']; ?></td>
+                <td><?php echo $order['user_id']; ?></td>
+                <td><?php echo $order['side']; ?></td>
+                <td><?php echo $order['amount']; ?></td>
+                <td><?php echo $order['price']; ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <p><a href="dashboard.php">Back</a></p>
+</body>
+</html>

--- a/public/p2p_offers.php
+++ b/public/p2p_offers.php
@@ -1,0 +1,48 @@
+<?php
+session_start();
+require_once '../config/db.php';
+
+if (!isset($_SESSION['user_id'])) {
+    header('Location: login.php');
+    exit;
+}
+
+// Handle new offer creation
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $amount = floatval($_POST['amount'] ?? 0);
+    $price = floatval($_POST['price'] ?? 0);
+    if ($amount > 0 && $price > 0) {
+        $stmt = $pdo->prepare('INSERT INTO p2p_offers (user_id, amount, price) VALUES (:user, :amount, :price)');
+        $stmt->execute([':user' => $_SESSION['user_id'], ':amount' => $amount, ':price' => $price]);
+    }
+}
+
+$offers = $pdo->query('SELECT * FROM p2p_offers ORDER BY id DESC')->fetchAll();
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>P2P Offers</title>
+</head>
+<body>
+    <h1>P2P Offers</h1>
+    <form method="post">
+        <label>Amount: <input type="number" step="0.0001" name="amount" required></label><br>
+        <label>Price: <input type="number" step="0.01" name="price" required></label><br>
+        <button type="submit">Create Offer</button>
+    </form>
+    <h2>Existing Offers</h2>
+    <table border="1">
+        <tr><th>ID</th><th>User</th><th>Amount</th><th>Price</th></tr>
+        <?php foreach ($offers as $offer): ?>
+            <tr>
+                <td><?php echo $offer['id']; ?></td>
+                <td><?php echo $offer['user_id']; ?></td>
+                <td><?php echo $offer['amount']; ?></td>
+                <td><?php echo $offer['price']; ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <p><a href="dashboard.php">Back</a></p>
+</body>
+</html>

--- a/public/register.php
+++ b/public/register.php
@@ -1,0 +1,31 @@
+<?php
+session_start();
+require_once '../config/db.php';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $email = $_POST['email'] ?? '';
+    $password = $_POST['password'] ?? '';
+    if ($email && $password) {
+        $hashed = password_hash($password, PASSWORD_BCRYPT);
+        $stmt = $pdo->prepare('INSERT INTO users (email, password) VALUES (:email, :password)');
+        $stmt->execute([':email' => $email, ':password' => $hashed]);
+        header('Location: login.php');
+        exit;
+    }
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Register</title>
+</head>
+<body>
+    <h1>Register</h1>
+    <form method="post">
+        <label>Email: <input type="email" name="email" required></label><br>
+        <label>Password: <input type="password" name="password" required></label><br>
+        <button type="submit">Register</button>
+    </form>
+    <p><a href="index.php">Home</a></p>
+</body>
+</html>

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -1,0 +1,44 @@
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE wallets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    currency VARCHAR(10) NOT NULL,
+    balance DECIMAL(18,8) NOT NULL DEFAULT 0,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE p2p_offers (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    amount DECIMAL(18,8) NOT NULL,
+    price DECIMAL(18,2) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE orders (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    side ENUM('buy','sell') NOT NULL,
+    amount DECIMAL(18,8) NOT NULL,
+    price DECIMAL(18,2) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE transactions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    buyer_id INT NOT NULL,
+    seller_id INT NOT NULL,
+    amount DECIMAL(18,8) NOT NULL,
+    price DECIMAL(18,2) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (buyer_id) REFERENCES users(id),
+    FOREIGN KEY (seller_id) REFERENCES users(id)
+);


### PR DESCRIPTION
## Summary
- init config, public and SQL folders
- add DB connection handler
- implement basic registration/login and dashboard
- add simple P2P offer and market views
- document setup instructions

## Testing
- `php -l config/db.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684183630c70832382ebbbdb97e5c618